### PR TITLE
update plugin use documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,10 @@ By default this plugin will generate a single sitemap of all pages on your site,
 ```javascript
 // gatsby-config.js
 
-const plugins = [
+siteMetadata: {
+    siteUrl: `https://www.example.com`,
+},
+plugins: [
     `gatsby-plugin-advanced-sitemap`
 ]
 ```


### PR DESCRIPTION
Without specifying `siteUrl` in `siteMetadata` this plugin throws a build error. While obvious to many, it may be confusing to some who follow the "how to use" instructions verbatim.