### PR TITLE
Use unionWith to merge nodes

### DIFF
--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -236,7 +236,11 @@ const serialize = ({ ...sources } = {},{ site, allSitePage }, mapping) => {
 
     const pageNodes = addPageNodes(nodes, allSitePage.edges, siteUrl)
 
-    const allNodes = _.merge(nodes, pageNodes)
+    const allNodes = _.unionWith(
+        nodes,
+        pageNodes,
+        (obj, src) => obj.url === src.url
+    );
 
     return allNodes
 }

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -240,7 +240,7 @@ const serialize = ({ ...sources } = {},{ site, allSitePage }, mapping) => {
         nodes,
         pageNodes,
         (obj, src) => obj.url === src.url
-    );
+    )
 
     return allNodes
 }


### PR DESCRIPTION
Fixes #22 

Uses unionWith to compare the URLs. Doesn't attempt to merge duplicates but rather ignores duplicate URLs in `pageNodes`: "Result values are chosen from the first array in which the value occurs" (https://lodash.com/docs/4.17.15#unionWith).

I don't see an issue with ignoring duplicate URLs as duplicate URLs shouldn't exist in the first place. However I'm not certain if result values should be preferred from `nodes` or from `pageNodes`.