### PR TITLE
Consider __typename for source type as query may be aliased

### DIFF
--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -164,7 +164,8 @@ const runQuery = (handler, { query, exclude }) => handler(query).then((r) => {
         // Removing excluded paths
         if (r.data[source] && r.data[source].edges && r.data[source].edges.length) {
             r.data[source].edges = r.data[source].edges.filter(({ node }) => !exclude.some((excludedRoute) => {
-                const slug = (source === `allMarkdownRemark` || source === `allMdx`) ? node.fields.slug.replace(/^\/|\/$/, ``) : node.slug.replace(/^\/|\/$/, ``)
+                const sourceType = node.__typename ? `all${node.__typename}` : source;
+                const slug = (sourceType === `allMarkdownRemark` || sourceType === `allMdx`) ? node.fields.slug.replace(/^\/|\/$/, ``) : node.slug.replace(/^\/|\/$/, ``)
                 excludedRoute = typeof excludedRoute === `object` ? excludedRoute : excludedRoute.replace(/^\/|\/$/, ``)
 
                 // test if the passed regular expression is valid

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -208,8 +208,8 @@ const serialize = ({ ...sources } = {}, { site, allSitePage }, { mapping, addUnc
                     if (!node) {
                         return
                     }
-
-                    if (type === `allMarkdownRemark` || type === `allMdx`) {
+                    const nodeType = node.__typename ? `all${node.__typename}` : type;
+                    if (nodeType === `allMarkdownRemark` || nodeType === `allMdx`) {
                         node = serializeMarkdownNodes(node)
                     }
 

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -164,7 +164,7 @@ const runQuery = (handler, { query, exclude }) => handler(query).then((r) => {
         // Removing excluded paths
         if (r.data[source] && r.data[source].edges && r.data[source].edges.length) {
             r.data[source].edges = r.data[source].edges.filter(({ node }) => !exclude.some((excludedRoute) => {
-                const sourceType = node.__typename ? `all${node.__typename}` : source;
+                const sourceType = node.__typename ? `all${node.__typename}` : source
                 const slug = (sourceType === `allMarkdownRemark` || sourceType === `allMdx`) ? node.fields.slug.replace(/^\/|\/$/, ``) : node.slug.replace(/^\/|\/$/, ``)
                 excludedRoute = typeof excludedRoute === `object` ? excludedRoute : excludedRoute.replace(/^\/|\/$/, ``)
 
@@ -208,7 +208,7 @@ const serialize = ({ ...sources } = {}, { site, allSitePage }, { mapping, addUnc
                     if (!node) {
                         return
                     }
-                    const nodeType = node.__typename ? `all${node.__typename}` : type;
+                    const nodeType = node.__typename ? `all${node.__typename}` : type
                     if (nodeType === `allMarkdownRemark` || nodeType === `allMdx`) {
                         node = serializeMarkdownNodes(node)
                     }


### PR DESCRIPTION
For a query like this:

```graphql
  posts: allMarkdownRemark(filter: {frontmatter: {draft: {ne: true}, template: {eq: "post"}}}) {
    edges {
      node {
        id
        fields {
          slug
        }
      }
    }
  }
	pages: allMarkdownRemark(filter: {frontmatter: {draft: {ne: true}, template: {in: ["page", "lego", "listing"]}}}) {
    edges {
      node {
        __typename
        id
        fields {
          slug
        }
      }
    }
  }
```

the if conditions for `source === 'allMarkdownRemark'` fail as the query is aliased.

Use `__typename` if available instead