### PR TITLE
Do not search for a real path for "/"

### DIFF
--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -73,7 +73,7 @@ const serializeMarkdownNodes = (node) => {
 // Compare our node paths with the ones that Gatsby has generated and updated them
 // with the "real" used ones.
 const getNodePath = (node, allSitePage) => {
-    if (!node.path || node.path === '/') {
+    if (!node.path || node.path === `/`) {
         return node
     }
     const slugRegex = new RegExp(`${node.path.replace(/\/$/, ``)}$`, `gi`)

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -73,7 +73,7 @@ const serializeMarkdownNodes = (node) => {
 // Compare our node paths with the ones that Gatsby has generated and updated them
 // with the "real" used ones.
 const getNodePath = (node, allSitePage) => {
-    if (!node.path) {
+    if (!node.path || node.path === '/') {
         return node
     }
     const slugRegex = new RegExp(`${node.path.replace(/\/$/, ``)}$`, `gi`)


### PR DESCRIPTION
Regex created in `getNodePath` for `/` matches any path (which is then filtered by `_.uniqBy`) and the homepage is not included in a sitemap if `addUncaughtPages` option is disabled.

Fixes #9