### PR TITLE
fix: The "url" argument must be of type string. Received undefined

### DIFF
--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -57,10 +57,6 @@ const serializeMarkdownNodes = (node) => {
         delete node.fields.slug;
     }
 
-    node.slug = node.fields.slug;
-
-    delete node.fields.slug;
-
     if (node.frontmatter) {
         if (node.frontmatter.published_at) {
             node.published_at = node.frontmatter.published_at;


### PR DESCRIPTION
I did not want to open new issue, here is the problem. 
With following config:
```{
    resolve: `gatsby-plugin-advanced-sitemap`,
    options: {
      query: `
                {
                allMarkdownRemark{
                    edges {
                        node {
                            id
                            frontmatter {
                                published_at: date
                                feature_image: image
                            }
                            fields {
                                slug
                            }
                        }
                    }
                }
            }`,
      mapping: {
        allMarkdownRemark: {
          sitemap: `pages`,
        },
      },
}
```

following error occurs:
```
 ERROR #11321  PLUGIN

"gatsby-plugin-advanced-sitemap" threw an error while running the onPostBuild lifecycle:

The "url" argument must be of type string. Received undefined

  316 |           node = getNodePath(node, allSitePage);
  317 |           sourceObject[mapping[type].sitemap].push({
> 318 |             url: _url.default.resolve(siteURL, node.path),
      |                               ^
  319 |             node: node
  320 |           });
  321 |         });

File: node_modules\gatsby-plugin-advanced-sitemap\gatsby-node.js:318:31

```