### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "eslint-plugin-ghost": "2.0.0",
     "eslint-plugin-jest": "24.3.1",
     "eslint-plugin-react": "7.22.0",
-    "gatsby": "2.32.0",
+    "gatsby": "3.0.0",
     "jest": "26.6.3",
     "react": "17.0.1",
     "react-dom": "17.0.1"


### PR DESCRIPTION
This change don't let show the warn:
Plugin gatsby-plugin-advanced-sitemap is not compatible with your gatsby version 3.1.0 - It requires gatsby@^2.0.0