### PR TITLE
Bug with index page lastUpdated date. Option to remove Ghost attribution.

### DIFF
--- a/src/SiteMapManager.js
+++ b/src/SiteMapManager.js
@@ -23,9 +23,10 @@ export default class SiteMapManager {
             this[type] = options[type] || this.createSiteMapGenerator(options, type);
         });
 
-        this.index = options.index || this.createIndexGenerator(sitemapTypes);
         // create the default pages one for all fallback sitemap URLs
         this.pages = options.pages || this.createSiteMapGenerator(options, `pages`);
+
+	this.index = options.index || this.createIndexGenerator(sitemapTypes);
     }
 
     createIndexGenerator(sitemapTypes) {

--- a/src/SiteMapManager.js
+++ b/src/SiteMapManager.js
@@ -26,7 +26,7 @@ export default class SiteMapManager {
         // create the default pages one for all fallback sitemap URLs
         this.pages = options.pages || this.createSiteMapGenerator(options, `pages`);
 
-	this.index = options.index || this.createIndexGenerator(sitemapTypes);
+        this.index = options.index || this.createIndexGenerator(sitemapTypes);
     }
 
     createIndexGenerator(sitemapTypes) {

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -33,7 +33,7 @@ const DEFAULTMAPPING = {
 };
 let siteURL;
 
-const copyStylesheet = async ({siteUrl, pathPrefix, indexOutput}) => {
+const copyStylesheet = async ({siteUrl, pathPrefix, indexOutput, hideAttribution}) => {
     const siteRegex = /(\{\{blog-url\}\})/g;
 
     // Get our stylesheet template
@@ -42,6 +42,10 @@ const copyStylesheet = async ({siteUrl, pathPrefix, indexOutput}) => {
     // Replace the `{{blog-url}}` variable with our real site URL
     const sitemapStylesheet = data.toString().replace(siteRegex, url.resolve(siteUrl, path.join(pathPrefix, indexOutput)));
 
+    // Hide Ghost attribution if set by user
+    if (hideAttribution) {
+        sitemapStylesheet = sitemapStylesheet.replace(/<p.*?Ghost.*?\/p>/s, '')
+    }
     // Save the updated stylesheet to the public folder, so it will be
     // available for the xml sitemap files
     await utils.writeFile(path.join(PUBLICPATH, `sitemap.xsl`), sitemapStylesheet);
@@ -164,7 +168,7 @@ const runQuery = (handler, {query, mapping, exclude}) => handler(query).then((r)
     for (let source in r.data) {
         // Check for custom serializer
         if (typeof mapping?.[source]?.serializer === `function`) {
-            if (r.data[source] && Array.isArray(r.data[source].edges)) { 
+            if (r.data[source] && Array.isArray(r.data[source].edges)) {
                 const serializedEdges = mapping[source].serializer(r.data[source].edges);
 
                 if (!Array.isArray(serializedEdges)) {
@@ -176,10 +180,10 @@ const runQuery = (handler, {query, mapping, exclude}) => handler(query).then((r)
 
         // Removing excluded paths
         if (r.data?.[source]?.edges && r.data[source].edges.length) {
-            r.data[source].edges = r.data[source].edges.filter(({node}) => !exclude.some((excludedRoute) => { 
+            r.data[source].edges = r.data[source].edges.filter(({node}) => !exclude.some((excludedRoute) => {
                 const sourceType = node.__typename ? `all${node.__typename}` : source;
                 const slug = (sourceType === `allMarkdownRemark` || sourceType === `allMdx`) || (node?.fields?.slug) ? node.fields.slug.replace(/^\/|\/$/, ``) : node.slug.replace(/^\/|\/$/, ``);
-                
+
                 excludedRoute = typeof excludedRoute === `object` ? excludedRoute : excludedRoute.replace(/^\/|\/$/, ``);
 
                 // test if the passed regular expression is valid

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -40,11 +40,11 @@ const copyStylesheet = async ({siteUrl, pathPrefix, indexOutput, hideAttribution
     const data = await utils.readFile(XSLFILE);
 
     // Replace the `{{blog-url}}` variable with our real site URL
-    const sitemapStylesheet = data.toString().replace(siteRegex, url.resolve(siteUrl, path.join(pathPrefix, indexOutput)));
+    let sitemapStylesheet = data.toString().replace(siteRegex, url.resolve(siteUrl, path.join(pathPrefix, indexOutput)));
 
     // Hide Ghost attribution if set by user
     if (hideAttribution) {
-        sitemapStylesheet = sitemapStylesheet.replace(/<p.*?Ghost.*?\/p>/s, '')
+        sitemapStylesheet = sitemapStylesheet.replace(/<p.*?Ghost.*?\/p>/s, '');
     }
     // Save the updated stylesheet to the public folder, so it will be
     // available for the xml sitemap files


### PR DESCRIPTION
This PR does the following:

1. Re-order index and pages in SiteMapManager (This fixes an issue where index updatedAt page does not reflect the actual updatedAt page and instead provides the latest date).
2. Add `hideAttribution` option to hide the Ghost attribution for those that would want to hide them (especially when using this plugin without Ghost backend).

This is my first PR. If there are issues, or this is not welcomed, I'm happy to re-work / close it.