### PR TITLE
chore: support gatsby 4.0.0 as a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "ship": "STATUS=$(git status --porcelain); echo $STATUS; if [ -z \"$STATUS\" ]; then yarn publish && git push --follow-tags; fi"
   },
   "peerDependencies": {
-    "gatsby": "^3.0.0"
+    "gatsby": "^3.0.0 || ^4.0.0"
   },
   "devDependencies": {
     "@babel/cli": "7.14.3",


### PR DESCRIPTION
- Removes this peer dependency warning (in yarn 3)
<img width="954" alt="스크린샷 2022-02-07 오후 12 49 42" src="https://user-images.githubusercontent.com/20325202/152721706-e60a6b9d-dae8-4b45-9ce4-801d4cfe8ae4.png">