### PR TITLE
Fix getNodePath helper

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -7,7 +7,7 @@ const getNodePath = (node, allSitePage) => {
 
     const nodePath = allSitePage.get(node.path.replace(/\/$/, ``));
 
-    if (getNodePath){
+    if (nodePath){
         node.path = nodePath;
     }
 


### PR DESCRIPTION
Hey there 👋 ,

I discovered that while playing with the plugin in a Gatsby project with pathPrefix and some tricks about urls.

Anyway, I willingly used path which doesn't exists in Gatsby and the `getNodePath` helper is returning `undefined` setting all urls to `${siteUrl}/undefined`.

Looking at the code, I think that there is a small mistake in the code. There is a check on what is found in allSitePage. I suppose it was to verify it found something but instead there is a test on the `getNodePath` itself which doesn't make sense because it will be always true.

I propose a very targeted fix on that test. I think it's what was intended in the first place.